### PR TITLE
feat(frontent): :sparkles: Add moving background back to the page

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,8 @@
         "socket.io": "^4.6.2",
         "socket.io-client": "^4.6.2",
         "tailwind-merge": "^1.12.0",
+        "three": "^0.134.0",
+        "vanta": "^0.5.24",
         "xterm": "^5.2.1"
       },
       "devDependencies": {
@@ -33,6 +35,7 @@
         "@testing-library/react": "^13.4.0",
         "@types/express": "^4.17.17",
         "@types/react": "^18.2.7",
+        "@types/three": "^0.137.0",
         "@typescript-eslint/eslint-plugin": "^5.59.7",
         "@typescript-eslint/parser": "^5.59.7",
         "autoprefixer": "^10.4.14",
@@ -3719,6 +3722,12 @@
       "dependencies": {
         "@types/jest": "*"
       }
+    },
+    "node_modules/@types/three": {
+      "version": "0.137.0",
+      "resolved": "https://registry.npmjs.org/@types/three/-/three-0.137.0.tgz",
+      "integrity": "sha512-Xc5EAlfYmgrCLI/VlSVqiRJAtzhWF0Rw2jSq48nqJy+Hcb5sfDOXyfZn1+RNcHyi9l8CeCAXCZygO8IyeOJVEA==",
+      "dev": true
     },
     "node_modules/@types/yargs": {
       "version": "16.0.4",
@@ -11556,6 +11565,11 @@
         "node": ">=0.8"
       }
     },
+    "node_modules/three": {
+      "version": "0.134.0",
+      "resolved": "https://registry.npmjs.org/three/-/three-0.134.0.tgz",
+      "integrity": "sha512-LbBerg7GaSPjYtTOnu41AMp7tV6efUNR3p4Wk5NzkSsNTBuA5mDGOfwwZL1jhhVMLx9V20HolIUo0+U3AXehbg=="
+    },
     "node_modules/throat": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/throat/-/throat-6.0.1.tgz",
@@ -12024,6 +12038,11 @@
         "spdx-correct": "^3.0.0",
         "spdx-expression-parse": "^3.0.0"
       }
+    },
+    "node_modules/vanta": {
+      "version": "0.5.24",
+      "resolved": "https://registry.npmjs.org/vanta/-/vanta-0.5.24.tgz",
+      "integrity": "sha512-fvieEbHy1ZS23zrcX+topzqAgA4Uct1enngOEWLFBgs9TtOf6RDFOYatH7KSVdrABzQDMCQ5myQy+nTSZZwLzg=="
     },
     "node_modules/vary": {
       "version": "1.1.2",

--- a/package.json
+++ b/package.json
@@ -33,6 +33,8 @@
     "socket.io": "^4.6.2",
     "socket.io-client": "^4.6.2",
     "tailwind-merge": "^1.12.0",
+    "three": "^0.134.0",
+    "vanta": "^0.5.24",
     "xterm": "^5.2.1"
   },
   "devDependencies": {
@@ -44,6 +46,7 @@
     "@testing-library/react": "^13.4.0",
     "@types/express": "^4.17.17",
     "@types/react": "^18.2.7",
+    "@types/three": "^0.137.0",
     "@typescript-eslint/eslint-plugin": "^5.59.7",
     "@typescript-eslint/parser": "^5.59.7",
     "autoprefixer": "^10.4.14",

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -19,7 +19,9 @@ import {
 } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import Link from 'next/link';
-import { ReactElement } from 'react';
+import { ReactElement, useEffect, useRef, useState } from 'react';
+import * as THREE from 'three';
+import NET from 'vanta/dist/vanta.net.min';
 
 interface Props {
   children: ReactElement[];
@@ -69,6 +71,35 @@ function SidebarLink({ name, active, icon, link }: SidebarProps) {
 }
 
 export default function Sidebar({ children, active = 'dashboard' }: Props) {
+  const [vantaEffect, setVantaEffect] = useState<typeof NET>(null);
+  const vantaRef = useRef(null);
+  useEffect(() => {
+    if (!vantaEffect) {
+      setVantaEffect(
+        NET({
+          el: vantaRef.current,
+          THREE,
+          mouseControls: false,
+          touchControls: false,
+          gyroControls: false,
+          minHeight: 200.0,
+          minWidth: 200.0,
+          backgroundColor: 0x26282c,
+          color: 0xd5a245,
+          scale: 1.0,
+          scaleMobile: 1.0,
+          points: 10.0,
+          maxDistance: 20.0,
+          spacing: 15.0,
+        })
+      );
+    }
+
+    return () => {
+      if (vantaEffect) vantaEffect.destroy();
+    };
+  }, [vantaEffect]);
+
   return (
     <div className='min-h-main flex'>
       <div
@@ -150,7 +181,11 @@ export default function Sidebar({ children, active = 'dashboard' }: Props) {
           link='mith'
         />
       </div>
-      <div className='min-h-main' style={{ width: 'calc(100vw - 19.5rem)' }}>
+      <div
+        className='min-h-main'
+        style={{ width: 'calc(100vw - 19.5rem)' }}
+        ref={vantaRef}
+      >
         <div className='h-full p-9 text-gray-100'>{children}</div>
       </div>
     </div>

--- a/vanta.types.d.ts
+++ b/vanta.types.d.ts
@@ -1,0 +1,9 @@
+// Copyright (c) 2023 Yağız Işkırık
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+declare module 'vanta/dist/vanta.net.min' {
+  const net: any; // eslint-disable-line
+  export default net;
+}


### PR DESCRIPTION
# Description & Technical Solution

- Added vanta background.
- Added vanta typescript types.

# Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have already run the `npm run prepush` command and there were no issues.
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] Already rebased against main branch.

# Screenshots

None.
