### PR TITLE
feat(frontent): :wrench: Edit Terminal page for the original look

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,8 @@
         "tailwind-merge": "^1.12.0",
         "three": "^0.134.0",
         "vanta": "^0.5.24",
-        "xterm": "^5.2.1"
+        "xterm": "^5.2.1",
+        "xterm-addon-fit": "^0.7.0"
       },
       "devDependencies": {
         "@commitlint/cli": "^16.3.0",
@@ -12380,6 +12381,14 @@
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/xterm/-/xterm-5.2.1.tgz",
       "integrity": "sha512-cs5Y1fFevgcdoh2hJROMVIWwoBHD80P1fIP79gopLHJIE4kTzzblanoivxTiQ4+92YM9IxS36H1q0MxIJXQBcA=="
+    },
+    "node_modules/xterm-addon-fit": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/xterm-addon-fit/-/xterm-addon-fit-0.7.0.tgz",
+      "integrity": "sha512-tQgHGoHqRTgeROPnvmtEJywLKoC/V9eNs4bLLz7iyJr1aW/QFzRwfd3MGiJ6odJd9xEfxcW36/xRU47JkD5NKQ==",
+      "peerDependencies": {
+        "xterm": "^5.0.0"
+      }
     },
     "node_modules/y18n": {
       "version": "5.0.8",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,8 @@
     "tailwind-merge": "^1.12.0",
     "three": "^0.134.0",
     "vanta": "^0.5.24",
-    "xterm": "^5.2.1"
+    "xterm": "^5.2.1",
+    "xterm-addon-fit": "^0.7.0"
   },
   "devDependencies": {
     "@commitlint/cli": "^16.3.0",

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -24,7 +24,7 @@ import * as THREE from 'three';
 import NET from 'vanta/dist/vanta.net.min';
 
 interface Props {
-  children: ReactElement[];
+  children: ReactElement[] | ReactElement;
   active?:
     | 'dashboard'
     | 'setup'

--- a/src/components/Terminal.tsx
+++ b/src/components/Terminal.tsx
@@ -6,6 +6,7 @@
 import { useEffect } from 'react';
 import { type Socket, io } from 'socket.io-client';
 import { Terminal } from 'xterm';
+import { FitAddon } from 'xterm-addon-fit';
 
 import 'xterm/css/xterm.css';
 let socket: Socket;
@@ -13,7 +14,10 @@ let socket: Socket;
 export default function Term() {
   useEffect(() => {
     const term = new Terminal();
+    const fitAddon = new FitAddon();
+    term.loadAddon(fitAddon);
     term.open(document.getElementById('terminal') as HTMLElement);
+    fitAddon.fit();
     term.onData((data) => {
       socket.emit('chat message', data);
     });
@@ -37,5 +41,5 @@ export default function Term() {
       socket.disconnect();
     };
   });
-  return <div id='terminal' className='text-left'></div>;
+  return <div id='terminal' className='px-2 pb-1 text-left'></div>;
 }

--- a/src/pages/terminal.tsx
+++ b/src/pages/terminal.tsx
@@ -3,8 +3,11 @@
 // This software is released under the MIT License.
 // https://opensource.org/licenses/MIT
 
+import { faLock } from '@fortawesome/free-solid-svg-icons';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import dynamic from 'next/dynamic';
 
+import NextImage from '@/components/NextImage';
 import Sidebar from '@/components/Sidebar';
 
 const Term = dynamic(() => import('@/components/Terminal'), { ssr: false });
@@ -15,12 +18,34 @@ export default function TerminalPage() {
       <h3 className='glitch' data-text='Terminal'>
         Terminal
       </h3>
-      <h1 className='mt-4'>Next.js Terminal Test</h1>
-      <p className='mb-3 mt-2 text-sm text-gray-400'>
-        A brilliant test (apparently, now working) of terminal test in Next.js
-        with Express server running on different port.
-      </p>
-      <Term />
+      <div className='card terminal mt-7'>
+        <div className='ter-topbar'>
+          <div className='btns w-1/4'>
+            <div className='cls-btn bbttnn'></div>
+            <div className='mnm-btn bbttnn'></div>
+            <div className='full-btn bbttnn'></div>
+          </div>
+          <div className='address-bar flex w-1/2 items-center justify-center'>
+            <NextImage
+              src='/images/logo.png'
+              alt='Logo'
+              height={15}
+              width={15}
+            />
+            <p className='ml-2 !opacity-95'>Kali's Terminal</p>
+          </div>
+          <div className='address-bar flex w-1/4 items-center justify-end gap-1 p-5'>
+            <p className='text-sm'>h4ppy</p>
+            <FontAwesomeIcon
+              icon={faLock}
+              className='opacity-80'
+              height={15}
+              width={15}
+            />
+          </div>
+        </div>
+        <Term />
+      </div>
     </Sidebar>
   );
 }

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -581,6 +581,54 @@
   opacity: 0.7;
 }
 
+.card.terminal {
+  height: calc(100vh - 16.7rem);
+  background: linear-gradient(#1e1c14a2, #111417a2);
+  backdrop-filter: blur(3px);
+  -webkit-backdrop-filter: blur(3px);
+  border-radius: 1rem;
+  border-color: #5d4213;
+  border-width: 0.1px;
+  padding: 0;
+}
+
+.terminal .ter-topbar {
+  width: 100%;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  border-radius: 1rem 1rem 0 0;
+  background-color: #111417a2;
+}
+
+.terminal .btns {
+  display: flex;
+  padding: 1.5rem;
+  gap: 0.5rem;
+}
+
+.terminal .btns .bbttnn {
+  width: 12.5px;
+  height: 12.5px;
+  border-radius: 20px;
+}
+
+.cls-btn {
+  background-color: #ed493a;
+}
+
+.mnm-btn {
+  background-color: #edcc3a;
+}
+
+.full-btn {
+  background-color: #1ebb13;
+}
+
+.xterm-viewport {
+  background: none !important;
+}
+
 /* Fix for typescript rounded-caps error */
 .apexcharts-radial-series path,
 .apexcharts-radialbar-track path {


### PR DESCRIPTION
# Description & Technical Solution

- `xterm-addon-fit` package was installed in order to fit the content to view for terminal screen.
- Sidebar component now accepts single element as well.
- Terminal screen now adjusted to the original look with the styling applied.

# Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have already run the `npm run prepush` command and there were no issues.
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] Already rebased against main branch.

# Screenshots

None.