### PR TITLE
feat(frontent): :sparkles: Add setup page and Wi-Fi settings

### DIFF
--- a/src/components/Input.tsx
+++ b/src/components/Input.tsx
@@ -1,0 +1,75 @@
+// Copyright (c) 2023 Yağız Işkırık
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+import { faEye, faEyeSlash } from '@fortawesome/free-solid-svg-icons';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import clsx from 'clsx';
+import { ChangeEvent } from 'react';
+import { useState } from 'react';
+
+interface Props {
+  label: string;
+  value?: string;
+  changeEvent: (str: string) => void;
+  placeholder?: string;
+  start?: string;
+  hidable?: boolean;
+}
+
+export default function Input({
+  label,
+  value = '',
+  placeholder = '',
+  start,
+  changeEvent,
+  hidable = false,
+}: Props) {
+  const chgInternal = (e: ChangeEvent<HTMLInputElement>) => {
+    changeEvent(e.target.value);
+  };
+
+  const [isHidden, setIsHidden] = useState(true);
+
+  return (
+    <div className='w-full'>
+      <label className='block text-sm font-medium leading-6 text-gray-200'>
+        {label}
+      </label>
+      <div className='relative mt-2 rounded-md shadow-sm'>
+        {start && (
+          <div className='pointer-events-none absolute inset-y-0 left-0 flex items-center pl-3'>
+            <span className='text-neutral-500 sm:text-sm'>{start}</span>
+          </div>
+        )}
+        <input
+          type={hidable && isHidden ? 'password' : 'text'}
+          name='inp'
+          value={value}
+          className={clsx(
+            start ? 'pl-8' : 'pl-3',
+            hidable ? 'pr-9' : 'pr-3',
+            'focus:ring-primary-300 block w-full rounded-md border-0 bg-neutral-900/40 py-1.5 pr-3 text-neutral-100 ring-1 ring-inset ring-neutral-300 placeholder:text-neutral-500 focus:ring-2 focus:ring-inset sm:text-sm sm:leading-6'
+          )}
+          placeholder={placeholder}
+          onChange={chgInternal}
+        />
+        {hidable && (
+          <div className='absolute inset-y-0 right-0 flex items-center'>
+            <FontAwesomeIcon
+              icon={isHidden ? faEyeSlash : faEye}
+              height={15}
+              width={15}
+              className={clsx(
+                isHidden ? 'text-neutral-300' : 'text-primary-300',
+                'mr-3'
+              )}
+              onClick={() => setIsHidden(!isHidden)}
+            />
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -186,7 +186,7 @@ export default function Sidebar({ children, active = 'dashboard' }: Props) {
         style={{ width: 'calc(100vw - 19.5rem)' }}
         ref={vantaRef}
       >
-        <div className='h-full p-9 text-gray-100'>{children}</div>
+        <div className='h-full px-3 py-7 text-gray-100 md:p-9'>{children}</div>
       </div>
     </div>
   );

--- a/src/components/Toggle.tsx
+++ b/src/components/Toggle.tsx
@@ -1,0 +1,34 @@
+// Copyright (c) 2023 Yağız Işkırık
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+import { ChangeEvent } from 'react';
+
+interface Props {
+  toggle: boolean;
+  toggleSet: (val: boolean) => void;
+}
+
+export default function Toggle({ toggle, toggleSet }: Props) {
+  const setToggle = (e: ChangeEvent<HTMLInputElement>) => {
+    toggleSet(e.target.checked);
+  };
+
+  return (
+    <div className='flex items-center justify-center'>
+      <label className='flex cursor-pointer items-center'>
+        <div className='relative'>
+          <input
+            type='checkbox'
+            checked={toggle}
+            onChange={setToggle}
+            className='custom-toggle sr-only'
+          />
+          <div className='block h-6 w-10 rounded-full bg-neutral-500'></div>
+          <div className='dot absolute left-1 top-1 h-4 w-4 rounded-full bg-white transition'></div>
+        </div>
+      </label>
+    </div>
+  );
+}

--- a/src/components/buttons/Button.tsx
+++ b/src/components/buttons/Button.tsx
@@ -57,11 +57,11 @@ const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
           //#region  //*=========== Variants ===========
           [
             variant === 'primary' && [
-              'bg-primary-500 text-white',
-              'border-primary-600 border',
-              'hover:bg-primary-600 hover:text-white',
-              'active:bg-primary-700',
-              'disabled:bg-primary-700',
+              'bg-primary-300 text-white',
+              'border-primary-400 border',
+              'hover:bg-primary-400 hover:text-white',
+              'active:bg-primary-500',
+              'disabled:bg-primary-500',
             ],
             variant === 'outline' && [
               'text-primary-300',

--- a/src/pages/setup.tsx
+++ b/src/pages/setup.tsx
@@ -1,0 +1,160 @@
+// Copyright (c) 2023 Yağız Işkırık
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+import clsx from 'clsx';
+import { useState } from 'react';
+import { HiClipboardCheck } from 'react-icons/hi';
+
+import Button from '@/components/buttons/Button';
+import Input from '@/components/Input';
+import Sidebar from '@/components/Sidebar';
+import Toggle from '@/components/Toggle';
+
+export default function TerminalPage() {
+  const [selTab, setSelTab] = useState(0);
+  const [wifiName, setWifiName] = useState('');
+  const [wifiPwd, setWifiPwd] = useState('');
+  const [wifiVisible, setWifiVisible] = useState(false);
+
+  return (
+    <Sidebar active='setup'>
+      <h3 className='glitch' data-text='Setup'>
+        Setup
+      </h3>
+      <div className='card custom-bg mt-7 p-5'>
+        <div className='border-b border-neutral-700'>
+          <nav className='flex space-x-4'>
+            <button
+              className={clsx(
+                selTab == 0
+                  ? 'border-primary-300 text-primary-300 font-medium'
+                  : 'border-transparent text-neutral-500',
+                'hover:text-primary-300 inline-flex items-center gap-2 whitespace-nowrap border-b-[3px] px-1 py-2 text-xl'
+              )}
+              onClick={() => setSelTab(0)}
+            >
+              Wi-Fi
+            </button>
+            <button
+              className={clsx(
+                selTab == 1
+                  ? 'border-primary-300 text-primary-300 font-medium'
+                  : 'border-transparent text-neutral-500',
+                'hover:text-primary-300 inline-flex items-center gap-2 whitespace-nowrap border-b-[3px] px-1 py-2 text-xl'
+              )}
+              onClick={() => setSelTab(1)}
+            >
+              Card
+            </button>
+            <button
+              className={clsx(
+                selTab == 2
+                  ? 'border-primary-300 text-primary-300 font-medium'
+                  : 'border-transparent text-neutral-500',
+                'hover:text-primary-300 inline-flex items-center gap-2 whitespace-nowrap border-b-[3px] px-1 py-2 text-xl'
+              )}
+              onClick={() => setSelTab(2)}
+            >
+              Security
+            </button>
+          </nav>
+        </div>
+
+        {selTab == 0 && (
+          <>
+            <div className='mt-5'>
+              <div className='flex flex-col md:flex-row'>
+                <div className='w-full pr-4 md:w-2/5'>
+                  <h2 className='text-base'>Wi-Fi Connection</h2>
+                  <p className='text-sm opacity-80'>
+                    General Wi-Fi settings related to all-users visible content
+                  </p>
+                </div>
+                <div className='mt-3 w-full md:mt-0 md:w-3/5'>
+                  <div className='flex w-full items-center gap-4'>
+                    <Input
+                      label='Wi-Fi Name'
+                      value={wifiName}
+                      placeholder='h4ppy Wi-Fi station'
+                      changeEvent={setWifiName}
+                    />
+                    <Input
+                      label='Wi-Fi Password'
+                      value={wifiPwd}
+                      placeholder='12345678'
+                      changeEvent={setWifiPwd}
+                      hidable={true}
+                    />
+                  </div>
+                  <div className='mt-4 flex items-center justify-between'>
+                    <p>Wi-Fi Visible</p>
+                    <Toggle toggle={wifiVisible} toggleSet={setWifiVisible} />
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div className='mt-5 md:mt-7'>
+              <div className='flex flex-col md:flex-row'>
+                <div className='w-full pr-4 md:w-2/5'>
+                  <h2 className='text-base'>Hotspot</h2>
+                  <p className='text-sm opacity-80'>
+                    Your internal hotspot settings for the wireless access point
+                  </p>
+                </div>
+                <div className='mt-3 w-full md:mt-0 md:w-3/5'>
+                  <div className='flex w-full items-center gap-4'>
+                    <Input
+                      label='Internal IP'
+                      value={wifiName}
+                      placeholder='192.168.7.1'
+                      changeEvent={setWifiName}
+                    />
+                    <Input
+                      label='Channel'
+                      value={wifiPwd}
+                      placeholder='7'
+                      changeEvent={setWifiPwd}
+                    />
+                  </div>
+                  <div className='mt-3 flex w-full items-center gap-4'>
+                    <Input
+                      label='WPA'
+                      value={wifiName}
+                      placeholder='3'
+                      changeEvent={setWifiName}
+                    />
+                    <Input
+                      label='WPA Key Management'
+                      value={wifiPwd}
+                      placeholder='WPA-PSK'
+                      changeEvent={setWifiPwd}
+                    />
+                  </div>
+                  <div className='mt-3 flex w-full items-center gap-4'>
+                    <Input
+                      label='WPA Pairwise'
+                      value={wifiName}
+                      placeholder='TKIP'
+                      changeEvent={setWifiName}
+                    />
+                    <Input
+                      label='RSN Pairwise'
+                      value={wifiPwd}
+                      placeholder='CCMP'
+                      changeEvent={setWifiPwd}
+                    />
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div className='mt-5 flex justify-end'>
+              <Button leftIcon={HiClipboardCheck}>Save Changes</Button>
+            </div>
+          </>
+        )}
+      </div>
+    </Sidebar>
+  );
+}

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -573,6 +573,14 @@
   -webkit-backdrop-filter: blur(3px) !important;
 }
 
+.custom-toggle:checked ~ .dot {
+  transform: translateX(100%);
+}
+
+.custom-toggle:checked ~ .block {
+  @apply !bg-green-500;
+}
+
 .card {
   border-radius: 0.4rem;
 }


### PR DESCRIPTION
# Description & Technical Solution

- Create a generic input element.
- Create a generic toggle element.
- Fix sidebar padding for mobile devices.
- Change default button colours.
- Add setup page and append Wi-Fi settings tab into it.

# Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have already run the `npm run prepush` command and there were no issues.
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] Already rebased against main branch.

# Screenshots

None.
