### PR TITLE
feat(frontend): :wrench: Add charts to placement page

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -33,6 +33,7 @@
         "tailwind-merge": "^1.12.0",
         "three": "^0.134.0",
         "vanta": "^0.5.24",
+        "victory": "^36.6.11",
         "xterm": "^5.2.1",
         "xterm-addon-fit": "^0.7.0"
       },
@@ -6124,6 +6125,11 @@
         "d3-selection": "2 - 3"
       }
     },
+    "node_modules/d3-voronoi": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/d3-voronoi/-/d3-voronoi-1.1.4.tgz",
+      "integrity": "sha512-dArJ32hchFsrQ8uMiTBLq256MpnZjeuBtdHpaDlYuQyjU0CVzCJl/BVW+SkszaAeH95D/8gxqAhgx0ouAWAfRg=="
+    },
     "node_modules/d3-zoom": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/d3-zoom/-/d3-zoom-3.0.0.tgz",
@@ -6440,6 +6446,19 @@
       "dependencies": {
         "robust-predicates": "^3.0.0"
       }
+    },
+    "node_modules/delaunay-find": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/delaunay-find/-/delaunay-find-0.0.6.tgz",
+      "integrity": "sha512-1+almjfrnR7ZamBk0q3Nhg6lqSe6Le4vL0WJDSMx4IDbQwTpUTXPjxC00lqLBT8MYsJpPCbI16sIkw9cPsbi7Q==",
+      "dependencies": {
+        "delaunator": "^4.0.0"
+      }
+    },
+    "node_modules/delaunay-find/node_modules/delaunator": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/delaunator/-/delaunator-4.0.1.tgz",
+      "integrity": "sha512-WNPWi1IRKZfCt/qIDMfERkDp93+iZEmOxN2yy4Jg+Xhv8SLk2UTqqbe1sfiipn0and9QrE914/ihdx82Y/Giag=="
     },
     "node_modules/delayed-stream": {
       "version": "1.0.0",
@@ -9723,6 +9742,11 @@
       "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE= sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
       "dev": true
     },
+    "node_modules/json-stringify-safe": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+      "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA=="
+    },
     "node_modules/json5": {
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
@@ -10002,8 +10026,7 @@
     "node_modules/lodash": {
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-      "dev": true
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
     "node_modules/lodash.debounce": {
       "version": "4.0.8",
@@ -11419,6 +11442,11 @@
       "peerDependencies": {
         "react": "^18.2.0"
       }
+    },
+    "node_modules/react-fast-compare": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/react-fast-compare/-/react-fast-compare-3.2.2.tgz",
+      "integrity": "sha512-nsO+KSNgo1SbJqJEYRE9ERzo7YtYbou/OqjSQKxV7jcKox7+usiUVZOAC+XnDOABXggQTno0Y1CpVnuWEc1boQ=="
     },
     "node_modules/react-gauge-component": {
       "version": "1.1.0",
@@ -13481,6 +13509,445 @@
       "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/victory": {
+      "version": "36.6.11",
+      "resolved": "https://registry.npmjs.org/victory/-/victory-36.6.11.tgz",
+      "integrity": "sha512-pXtD0gEBw1wohctaeDDWAUwX+qR9OyKyUeI0bi/rmSPNf84TinIf1bWuAuUuEPb2v90ASLVkuz0nVAP//7FOdQ==",
+      "dependencies": {
+        "victory-area": "^36.6.11",
+        "victory-axis": "^36.6.11",
+        "victory-bar": "^36.6.11",
+        "victory-box-plot": "^36.6.11",
+        "victory-brush-container": "^36.6.11",
+        "victory-brush-line": "^36.6.11",
+        "victory-candlestick": "^36.6.11",
+        "victory-canvas": "^36.6.11",
+        "victory-chart": "^36.6.11",
+        "victory-core": "^36.6.11",
+        "victory-create-container": "^36.6.11",
+        "victory-cursor-container": "^36.6.11",
+        "victory-errorbar": "^36.6.11",
+        "victory-group": "^36.6.11",
+        "victory-histogram": "^36.6.11",
+        "victory-legend": "^36.6.11",
+        "victory-line": "^36.6.11",
+        "victory-pie": "^36.6.11",
+        "victory-polar-axis": "^36.6.11",
+        "victory-scatter": "^36.6.11",
+        "victory-selection-container": "^36.6.11",
+        "victory-shared-events": "^36.6.11",
+        "victory-stack": "^36.6.11",
+        "victory-tooltip": "^36.6.11",
+        "victory-voronoi": "^36.6.11",
+        "victory-voronoi-container": "^36.6.11",
+        "victory-zoom-container": "^36.6.11"
+      },
+      "peerDependencies": {
+        "react": ">=16.6.0"
+      }
+    },
+    "node_modules/victory-area": {
+      "version": "36.6.11",
+      "resolved": "https://registry.npmjs.org/victory-area/-/victory-area-36.6.11.tgz",
+      "integrity": "sha512-M/wQ0ryms6WpqGzpv+BMNfCLy0dlOtIxAuYgXJYwwDu55noAMbWlFahIzfllpjTmFOyCpCXF7EDraC3n2xRRFQ==",
+      "dependencies": {
+        "lodash": "^4.17.19",
+        "prop-types": "^15.8.1",
+        "victory-core": "^36.6.11",
+        "victory-vendor": "^36.6.11"
+      },
+      "peerDependencies": {
+        "react": ">=16.6.0"
+      }
+    },
+    "node_modules/victory-axis": {
+      "version": "36.6.11",
+      "resolved": "https://registry.npmjs.org/victory-axis/-/victory-axis-36.6.11.tgz",
+      "integrity": "sha512-f2PUbEsE5wYXKRrgSYdoPRV6QXKNrZjTcd8YlymVGWsouJEFRZFOig8N3yU5lM7OuP98tOdurk4I91Py6NlXrA==",
+      "dependencies": {
+        "lodash": "^4.17.19",
+        "prop-types": "^15.8.1",
+        "victory-core": "^36.6.11"
+      },
+      "peerDependencies": {
+        "react": ">=16.6.0"
+      }
+    },
+    "node_modules/victory-bar": {
+      "version": "36.6.11",
+      "resolved": "https://registry.npmjs.org/victory-bar/-/victory-bar-36.6.11.tgz",
+      "integrity": "sha512-ANXZIYiDcvC1k3fvGbE8qHOi0POGOsYbzTgP/SBHXh9VQYa/NaYGZT3RO1mxp8wgpwaF+NZYZNC8mMO1pvcB2w==",
+      "dependencies": {
+        "lodash": "^4.17.19",
+        "prop-types": "^15.8.1",
+        "victory-core": "^36.6.11",
+        "victory-vendor": "^36.6.11"
+      },
+      "peerDependencies": {
+        "react": ">=16.6.0"
+      }
+    },
+    "node_modules/victory-box-plot": {
+      "version": "36.6.11",
+      "resolved": "https://registry.npmjs.org/victory-box-plot/-/victory-box-plot-36.6.11.tgz",
+      "integrity": "sha512-+J7Hb0Vf6cQe+qZyRhm6sM7V7AMS43jSTXnrFtRP7Bn+HdAb7p2S7h8abtgUhg3uVeTQa9UUqJBmC/maP8V3Nw==",
+      "dependencies": {
+        "lodash": "^4.17.19",
+        "prop-types": "^15.8.1",
+        "victory-core": "^36.6.11",
+        "victory-vendor": "^36.6.11"
+      },
+      "peerDependencies": {
+        "react": ">=16.6.0"
+      }
+    },
+    "node_modules/victory-brush-container": {
+      "version": "36.6.11",
+      "resolved": "https://registry.npmjs.org/victory-brush-container/-/victory-brush-container-36.6.11.tgz",
+      "integrity": "sha512-o0pPKzfQhKRlYNYUx3tHjuv9iTXqvgRtmu59L/h6l11DPaRo+jcHDBKEDRuoZxTinR/a1yqfLEJ1i9QgSE8o6w==",
+      "dependencies": {
+        "lodash": "^4.17.19",
+        "prop-types": "^15.8.1",
+        "react-fast-compare": "^3.2.0",
+        "victory-core": "^36.6.11"
+      },
+      "peerDependencies": {
+        "react": ">=16.6.0"
+      }
+    },
+    "node_modules/victory-brush-line": {
+      "version": "36.6.11",
+      "resolved": "https://registry.npmjs.org/victory-brush-line/-/victory-brush-line-36.6.11.tgz",
+      "integrity": "sha512-AYZvqq25nc7wOP4w7ysWAkhZnkuG28zah+6M1gJqcdeZov6dkiblda66vpwDOR1sCAGiHtLGR1pkUm+p02ikJw==",
+      "dependencies": {
+        "lodash": "^4.17.19",
+        "prop-types": "^15.8.1",
+        "react-fast-compare": "^3.2.0",
+        "victory-core": "^36.6.11"
+      },
+      "peerDependencies": {
+        "react": ">=16.6.0"
+      }
+    },
+    "node_modules/victory-candlestick": {
+      "version": "36.6.11",
+      "resolved": "https://registry.npmjs.org/victory-candlestick/-/victory-candlestick-36.6.11.tgz",
+      "integrity": "sha512-4R2aYq4opG7ONv//OjJmSPXfVgPdb3xoNiBPfs832Kon0vlfcIltvge34YEn0qkanlcp1Vg/GvxvKa/kxR45JA==",
+      "dependencies": {
+        "lodash": "^4.17.19",
+        "prop-types": "^15.8.1",
+        "victory-core": "^36.6.11"
+      },
+      "peerDependencies": {
+        "react": ">=16.6.0"
+      }
+    },
+    "node_modules/victory-canvas": {
+      "version": "36.6.11",
+      "resolved": "https://registry.npmjs.org/victory-canvas/-/victory-canvas-36.6.11.tgz",
+      "integrity": "sha512-0lzX9JabP6xpkn5VlHPYduYmg2dyMzvXGEbD17ZQNljOhvczkKkbOlps+v94y8MGsiXRLvkpwBMYf4V8m60lFQ==",
+      "dependencies": {
+        "lodash": "^4.17.19",
+        "prop-types": "^15.8.1",
+        "victory-bar": "^36.6.11",
+        "victory-core": "^36.6.11"
+      },
+      "peerDependencies": {
+        "react": ">=16.6.0"
+      }
+    },
+    "node_modules/victory-chart": {
+      "version": "36.6.11",
+      "resolved": "https://registry.npmjs.org/victory-chart/-/victory-chart-36.6.11.tgz",
+      "integrity": "sha512-t4RIeLT6PJxZaDqNeawtIPxuA48k98kBvYbEV9XEPrS3TPAYsrB6lgXjZKLoItYLh63Ry4nqZAnPti4RD0uTfQ==",
+      "dependencies": {
+        "lodash": "^4.17.19",
+        "prop-types": "^15.8.1",
+        "react-fast-compare": "^3.2.0",
+        "victory-axis": "^36.6.11",
+        "victory-core": "^36.6.11",
+        "victory-polar-axis": "^36.6.11",
+        "victory-shared-events": "^36.6.11"
+      },
+      "peerDependencies": {
+        "react": ">=16.6.0"
+      }
+    },
+    "node_modules/victory-core": {
+      "version": "36.6.11",
+      "resolved": "https://registry.npmjs.org/victory-core/-/victory-core-36.6.11.tgz",
+      "integrity": "sha512-aYhFIRu8NQMwW/JbgqoAG7w0lUYbTB1Achx4mmBc6aL8RMkv6LhD/PFwjT3TLpH0AoEs3Rpty2g0UQ+7ulE7dA==",
+      "dependencies": {
+        "lodash": "^4.17.21",
+        "prop-types": "^15.8.1",
+        "react-fast-compare": "^3.2.0",
+        "victory-vendor": "^36.6.11"
+      },
+      "peerDependencies": {
+        "react": ">=16.6.0"
+      }
+    },
+    "node_modules/victory-create-container": {
+      "version": "36.6.11",
+      "resolved": "https://registry.npmjs.org/victory-create-container/-/victory-create-container-36.6.11.tgz",
+      "integrity": "sha512-Ve96DE9XDifmT2Bh/6Ptz7cgIV5DC2GYsr0Rl6I0sF6S02IH3V02NLpkcTthTRJHAvC9MkHwjiBlvFEZsXHOtg==",
+      "dependencies": {
+        "lodash": "^4.17.19",
+        "victory-brush-container": "^36.6.11",
+        "victory-core": "^36.6.11",
+        "victory-cursor-container": "^36.6.11",
+        "victory-selection-container": "^36.6.11",
+        "victory-voronoi-container": "^36.6.11",
+        "victory-zoom-container": "^36.6.11"
+      },
+      "peerDependencies": {
+        "react": ">=16.6.0"
+      }
+    },
+    "node_modules/victory-cursor-container": {
+      "version": "36.6.11",
+      "resolved": "https://registry.npmjs.org/victory-cursor-container/-/victory-cursor-container-36.6.11.tgz",
+      "integrity": "sha512-rdQAZb3RGYfijjqIQkuPGLNY5UOhuqyzlxQFaVtkpkDSZKiPMtbfLvR7F0Yfa9cs8OeQU0KAtAiK8R33o7su/Q==",
+      "dependencies": {
+        "lodash": "^4.17.19",
+        "prop-types": "^15.8.1",
+        "victory-core": "^36.6.11"
+      },
+      "peerDependencies": {
+        "react": ">=16.6.0"
+      }
+    },
+    "node_modules/victory-errorbar": {
+      "version": "36.6.11",
+      "resolved": "https://registry.npmjs.org/victory-errorbar/-/victory-errorbar-36.6.11.tgz",
+      "integrity": "sha512-Umu8MZ2XtMNCxr8rRcf421FLywJlvQY86sGNqePaBbar4rqk6sqWAU8HKzttNjCEQ0xh579LmskleiutEBFf4g==",
+      "dependencies": {
+        "lodash": "^4.17.19",
+        "prop-types": "^15.8.1",
+        "victory-core": "^36.6.11"
+      },
+      "peerDependencies": {
+        "react": ">=16.6.0"
+      }
+    },
+    "node_modules/victory-group": {
+      "version": "36.6.11",
+      "resolved": "https://registry.npmjs.org/victory-group/-/victory-group-36.6.11.tgz",
+      "integrity": "sha512-PTRrH31gsGk3KFzeTzAkyvgjtilWYHWkx06oouh70KuAJ7f+9pRMrRMal8v+npH6a8Wp0KKW198AqpkPaZqHyQ==",
+      "dependencies": {
+        "lodash": "^4.17.19",
+        "prop-types": "^15.8.1",
+        "react-fast-compare": "^3.2.0",
+        "victory-core": "^36.6.11",
+        "victory-shared-events": "^36.6.11"
+      },
+      "peerDependencies": {
+        "react": ">=16.6.0"
+      }
+    },
+    "node_modules/victory-histogram": {
+      "version": "36.6.11",
+      "resolved": "https://registry.npmjs.org/victory-histogram/-/victory-histogram-36.6.11.tgz",
+      "integrity": "sha512-WOMfvshfzAgGn1Zh+/fLVW0kxQrVKYACFCdsKDEYmuG8dGvqmPilI3oljAqiYrafNagwVv+Otc0NNgW8ydLHcA==",
+      "dependencies": {
+        "lodash": "^4.17.19",
+        "prop-types": "^15.8.1",
+        "react-fast-compare": "^3.2.0",
+        "victory-bar": "^36.6.11",
+        "victory-core": "^36.6.11",
+        "victory-vendor": "^36.6.11"
+      },
+      "peerDependencies": {
+        "react": ">=16.6.0"
+      }
+    },
+    "node_modules/victory-legend": {
+      "version": "36.6.11",
+      "resolved": "https://registry.npmjs.org/victory-legend/-/victory-legend-36.6.11.tgz",
+      "integrity": "sha512-eL310Qh3WcZyjFI18hABVodwHpgZtokHD3r5HKpgZVY8MWkMD9mXErphWbkNHTVi5ya+I3QbRQ7ToRbPUl/Jog==",
+      "dependencies": {
+        "lodash": "^4.17.19",
+        "prop-types": "^15.8.1",
+        "victory-core": "^36.6.11"
+      },
+      "peerDependencies": {
+        "react": ">=16.6.0"
+      }
+    },
+    "node_modules/victory-line": {
+      "version": "36.6.11",
+      "resolved": "https://registry.npmjs.org/victory-line/-/victory-line-36.6.11.tgz",
+      "integrity": "sha512-SDQCS6qDSixnYPB1kHEQsue06N6x2cxkIA6uqL45LRFMkKWG4OtwTBORVhtK6lfKzq1OvJs3msoZ+uoRIW1gaA==",
+      "dependencies": {
+        "lodash": "^4.17.19",
+        "prop-types": "^15.8.1",
+        "victory-core": "^36.6.11",
+        "victory-vendor": "^36.6.11"
+      },
+      "peerDependencies": {
+        "react": ">=16.6.0"
+      }
+    },
+    "node_modules/victory-pie": {
+      "version": "36.6.11",
+      "resolved": "https://registry.npmjs.org/victory-pie/-/victory-pie-36.6.11.tgz",
+      "integrity": "sha512-vQPAzrubo3BX/1pujSlKKTBGNSj/8fxUJ0vSZPZ6EE1y6SRnPJoLYi2OkDQVT1s3rM9xvW00SflCD3GO/Z3xWA==",
+      "dependencies": {
+        "lodash": "^4.17.19",
+        "prop-types": "^15.8.1",
+        "victory-core": "^36.6.11",
+        "victory-vendor": "^36.6.11"
+      },
+      "peerDependencies": {
+        "react": ">=16.6.0"
+      }
+    },
+    "node_modules/victory-polar-axis": {
+      "version": "36.6.11",
+      "resolved": "https://registry.npmjs.org/victory-polar-axis/-/victory-polar-axis-36.6.11.tgz",
+      "integrity": "sha512-wDkyY1rKQTRUVt4+e0QNQgSIJCqXazNhkjWXla8ZWj52GzPP/QSDuzr8SO1oHA3++1jOpdD0R2FTxm+pAea/Yw==",
+      "dependencies": {
+        "lodash": "^4.17.19",
+        "prop-types": "^15.8.1",
+        "victory-core": "^36.6.11"
+      },
+      "peerDependencies": {
+        "react": ">=16.6.0"
+      }
+    },
+    "node_modules/victory-scatter": {
+      "version": "36.6.11",
+      "resolved": "https://registry.npmjs.org/victory-scatter/-/victory-scatter-36.6.11.tgz",
+      "integrity": "sha512-x46AfmhiKijXe59kqm7xI0CCjbY8J0VB02HUN3TynMx7xzhW2yOP+QQqgyk+C4im/MS33HKU402Q7cUfF3pgtw==",
+      "dependencies": {
+        "lodash": "^4.17.19",
+        "prop-types": "^15.8.1",
+        "victory-core": "^36.6.11"
+      },
+      "peerDependencies": {
+        "react": ">=16.6.0"
+      }
+    },
+    "node_modules/victory-selection-container": {
+      "version": "36.6.11",
+      "resolved": "https://registry.npmjs.org/victory-selection-container/-/victory-selection-container-36.6.11.tgz",
+      "integrity": "sha512-pRQz++0ERZVuIgxpmqLkDgf6hiCAS2m8iGcox8tryWzE1NpADG/IJiHh3AeJgGeiLNMeoJ48hsOZP1C9CCxwrQ==",
+      "dependencies": {
+        "lodash": "^4.17.19",
+        "prop-types": "^15.8.1",
+        "victory-core": "^36.6.11"
+      },
+      "peerDependencies": {
+        "react": ">=16.6.0"
+      }
+    },
+    "node_modules/victory-shared-events": {
+      "version": "36.6.11",
+      "resolved": "https://registry.npmjs.org/victory-shared-events/-/victory-shared-events-36.6.11.tgz",
+      "integrity": "sha512-ia6ijfgfYMb+gGFPEq4F6rqzB9p5EkjKpjvmEv4Ww7VjrtdORu7PPfAgTxXw/9QgFSq4iOUnDtzjObABua09fQ==",
+      "dependencies": {
+        "json-stringify-safe": "^5.0.1",
+        "lodash": "^4.17.19",
+        "prop-types": "^15.8.1",
+        "react-fast-compare": "^3.2.0",
+        "victory-core": "^36.6.11"
+      },
+      "peerDependencies": {
+        "react": ">=16.6.0"
+      }
+    },
+    "node_modules/victory-stack": {
+      "version": "36.6.11",
+      "resolved": "https://registry.npmjs.org/victory-stack/-/victory-stack-36.6.11.tgz",
+      "integrity": "sha512-kE/915RdcKes69WpxZ5j6MyCIJqdzIZnzIg6OArBeDlD+LuinNb2oNxYpMXzur1KFSyk5PCUckHgEbR2XLoXrw==",
+      "dependencies": {
+        "lodash": "^4.17.19",
+        "prop-types": "^15.8.1",
+        "react-fast-compare": "^3.2.0",
+        "victory-core": "^36.6.11",
+        "victory-shared-events": "^36.6.11"
+      },
+      "peerDependencies": {
+        "react": ">=16.6.0"
+      }
+    },
+    "node_modules/victory-tooltip": {
+      "version": "36.6.11",
+      "resolved": "https://registry.npmjs.org/victory-tooltip/-/victory-tooltip-36.6.11.tgz",
+      "integrity": "sha512-YxAPkGAqTYOIW4aE5InGFABmYjiBfuQFjCe9hwFGvIC/Uqn202xgs5kYVEZXUX3vc9W8XOl7plaQJzmtr2ZZBQ==",
+      "dependencies": {
+        "lodash": "^4.17.19",
+        "prop-types": "^15.8.1",
+        "victory-core": "^36.6.11"
+      },
+      "peerDependencies": {
+        "react": ">=16.6.0"
+      }
+    },
+    "node_modules/victory-vendor": {
+      "version": "36.6.11",
+      "resolved": "https://registry.npmjs.org/victory-vendor/-/victory-vendor-36.6.11.tgz",
+      "integrity": "sha512-nT8kCiJp8dQh8g991J/R5w5eE2KnO8EAIP0xocWlh9l2okngMWglOPoMZzJvek8Q1KUc4XE/mJxTZnvOB1sTYg==",
+      "dependencies": {
+        "@types/d3-array": "^3.0.3",
+        "@types/d3-ease": "^3.0.0",
+        "@types/d3-interpolate": "^3.0.1",
+        "@types/d3-scale": "^4.0.2",
+        "@types/d3-shape": "^3.1.0",
+        "@types/d3-time": "^3.0.0",
+        "@types/d3-timer": "^3.0.0",
+        "d3-array": "^3.1.6",
+        "d3-ease": "^3.0.1",
+        "d3-interpolate": "^3.0.1",
+        "d3-scale": "^4.0.2",
+        "d3-shape": "^3.1.0",
+        "d3-time": "^3.0.0",
+        "d3-timer": "^3.0.1"
+      }
+    },
+    "node_modules/victory-voronoi": {
+      "version": "36.6.11",
+      "resolved": "https://registry.npmjs.org/victory-voronoi/-/victory-voronoi-36.6.11.tgz",
+      "integrity": "sha512-Hu1S8HsM0YOUvzW0cp2LnEvgh6a+dXHkGfaI+Qyyz5P8uXFgBcBvvhzLbgawkrIOgbX/jU5Vpketvhm4ByuAqQ==",
+      "dependencies": {
+        "d3-voronoi": "^1.1.4",
+        "lodash": "^4.17.19",
+        "prop-types": "^15.8.1",
+        "victory-core": "^36.6.11"
+      },
+      "peerDependencies": {
+        "react": ">=16.6.0"
+      }
+    },
+    "node_modules/victory-voronoi-container": {
+      "version": "36.6.11",
+      "resolved": "https://registry.npmjs.org/victory-voronoi-container/-/victory-voronoi-container-36.6.11.tgz",
+      "integrity": "sha512-KNB814e5uhs00oNFdkPucXMlpNILnWabHM7iKLBz26nlgqiu6dctZZoWU+HKjxbPkHdic6JQsg28Nk5bThaulw==",
+      "dependencies": {
+        "delaunay-find": "0.0.6",
+        "lodash": "^4.17.19",
+        "prop-types": "^15.8.1",
+        "react-fast-compare": "^3.2.0",
+        "victory-core": "^36.6.11",
+        "victory-tooltip": "^36.6.11"
+      },
+      "peerDependencies": {
+        "react": ">=16.6.0"
+      }
+    },
+    "node_modules/victory-zoom-container": {
+      "version": "36.6.11",
+      "resolved": "https://registry.npmjs.org/victory-zoom-container/-/victory-zoom-container-36.6.11.tgz",
+      "integrity": "sha512-DRS12HZEmy5oJanlnSK9Wtp/6HQQbwvK0idVU+Lhf2lw3r9gauWp/ymWwWzaHd7Mn5cCODuNW1le2bqb71j3wg==",
+      "dependencies": {
+        "lodash": "^4.17.19",
+        "prop-types": "^15.8.1",
+        "victory-core": "^36.6.11"
+      },
+      "peerDependencies": {
+        "react": ">=16.6.0"
       }
     },
     "node_modules/w3c-hr-time": {

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "tailwind-merge": "^1.12.0",
     "three": "^0.134.0",
     "vanta": "^0.5.24",
+    "victory": "^36.6.11",
     "xterm": "^5.2.1",
     "xterm-addon-fit": "^0.7.0"
   },

--- a/src/components/ChartElement.tsx
+++ b/src/components/ChartElement.tsx
@@ -1,0 +1,73 @@
+// Copyright (c) 2023 Yağız Işkırık
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+import {
+  VictoryAxis,
+  VictoryChart,
+  VictoryLine,
+  VictoryScatter,
+} from 'victory';
+
+interface Props {
+  incData: number[];
+}
+
+export default function ChartElement({ incData }: Props) {
+  const dataConverter = (data: number[]) => {
+    return data.map((d, i) => ({ x: i, y: d }));
+  };
+
+  const data = dataConverter(incData);
+
+  return (
+    <VictoryChart height={300}>
+      <VictoryAxis
+        tickValues={Array.from(Array(data.length).keys())}
+        tickFormat={Array(data.length).fill('')}
+        style={{
+          tickLabels: { fill: 'rgb(200, 200, 200)' },
+          axis: { stroke: 'rgb(200, 200, 200)', strokeWidth: '2px' },
+          grid: {
+            stroke: 'rgba(200, 200, 200, 0.3)',
+            strokeDasharray: 5,
+          },
+        }}
+      />
+      <VictoryAxis
+        dependentAxis
+        tickFormat={(x) => `${x}%`}
+        style={{
+          tickLabels: { fill: 'rgb(200, 200, 200)' },
+          axis: { stroke: 'rgb(200, 200, 200)', strokeWidth: '2px' },
+          grid: {
+            stroke: 'rgba(200, 200, 200, 0.3)',
+            strokeDasharray: 5,
+          },
+        }}
+        domain={[0, 100]}
+      />
+      <VictoryLine
+        interpolation='catmullRom'
+        data={data}
+        style={{
+          data: {
+            stroke: 'rgb(var(--tw-color-primary-300)',
+          },
+        }}
+      />
+      <VictoryScatter
+        data={data}
+        size={3}
+        style={{
+          data: {
+            fill: 'white',
+            stroke: 'rgb(var(--tw-color-primary-300)',
+            strokeWidth: '1px',
+          },
+        }}
+      />
+    </VictoryChart>
+  );
+}

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -41,7 +41,8 @@ interface Props {
     | 'wifilockdown'
     | 'handshakecollector'
     | 'wifiblocker'
-    | 'maninthehouse';
+    | 'maninthehouse'
+    | '404';
 }
 
 interface SidebarProps {

--- a/src/pages/404.tsx
+++ b/src/pages/404.tsx
@@ -1,29 +1,24 @@
 import * as React from 'react';
 import { RiAlarmWarningFill } from 'react-icons/ri';
 
-import Layout from '@/components/layout/Layout';
 import ArrowLink from '@/components/links/ArrowLink';
 import Seo from '@/components/Seo';
+import Sidebar from '@/components/Sidebar';
 
 export default function NotFoundPage() {
   return (
-    <Layout>
+    <Sidebar data={{}} active='404'>
       <Seo templateTitle='Not Found' />
-
-      <main>
-        <section className='bg-white'>
-          <div className='layout flex min-h-screen flex-col items-center justify-center text-center text-black'>
-            <RiAlarmWarningFill
-              size={60}
-              className='drop-shadow-glow animate-flicker text-red-500'
-            />
-            <h1 className='mt-8 text-4xl md:text-6xl'>Page Not Found</h1>
-            <ArrowLink className='mt-4 md:text-lg' href='/'>
-              Back to Home
-            </ArrowLink>
-          </div>
-        </section>
-      </main>
-    </Layout>
+      <div className='flex h-full flex-col items-center justify-center text-center text-black'>
+        <RiAlarmWarningFill
+          size={60}
+          className='drop-shadow-glow animate-flicker text-red-500'
+        />
+        <h1 className='mt-8 text-4xl text-white md:text-6xl'>Page Not Found</h1>
+        <ArrowLink className='mt-4 text-white/75 md:text-lg' href='/'>
+          Back to Home
+        </ArrowLink>
+      </div>
+    </Sidebar>
   );
 }

--- a/src/pages/placement.tsx
+++ b/src/pages/placement.tsx
@@ -21,6 +21,9 @@ import Sidebar from '@/components/Sidebar';
 
 import SettingsType from '@/types/settingsType';
 
+const ChartElement = dynamic(() => import('@/components/ChartElement'), {
+  ssr: false,
+});
 const GaugeComponent = dynamic(() => import('react-gauge-component'), {
   ssr: false,
 });
@@ -34,6 +37,9 @@ export default function WifisAroundPage(data: SettingsType) {
   const [compSuccessRate, setCompSuccesRate] = useState(0);
   const [selectedWifi, setSelectedWifi] = useState('');
   const [isCompare, setIsCompare] = useState(false);
+
+  const [wifiSignalHistory, setWifiSignalHistory] = useState<number[]>([]);
+  const [clientSignalHistory, setClientSignalHistory] = useState<number[]>([]);
 
   // Seeds for chart refresh
   const [seed1, setSeed1] = useState(1);
@@ -56,6 +62,16 @@ export default function WifisAroundPage(data: SettingsType) {
       if (selectedWifi !== '') {
         const newWifiSignal = Math.round(Math.random() * 100);
         const newClientSignal = Math.round(Math.random() * 100);
+        setWifiSignalHistory((wifiSignalHistory) =>
+          wifiSignalHistory.length > 11
+            ? [...wifiSignalHistory.slice(1, 12), newWifiSignal]
+            : [...wifiSignalHistory, newWifiSignal]
+        );
+        setClientSignalHistory((clientSignalHistory) =>
+          clientSignalHistory.length > 11
+            ? [...clientSignalHistory.slice(1, 12), newClientSignal]
+            : [...clientSignalHistory, newClientSignal]
+        );
         setWifiSignal(newWifiSignal);
         setClientSignal(newClientSignal);
         setSuccesRate(calculateSuccessRate(newWifiSignal, newClientSignal));
@@ -397,6 +413,22 @@ export default function WifisAroundPage(data: SettingsType) {
               </div>
             </div>
           )}
+        </div>
+      </div>
+      <div className='card custom-bg my-7 p-5'>
+        <div className='grid grid-cols-1 grid-rows-2 md:grid-cols-2 md:grid-rows-1'>
+          <div>
+            <h3 className='text-primary-300 -mb-5 ml-4 mt-2 md:ml-8 md:mt-4'>
+              Wi-Fi Signal
+            </h3>
+            <ChartElement incData={wifiSignalHistory} />
+          </div>
+          <div>
+            <h3 className='text-primary-300 -mb-5 ml-4 mt-2 md:ml-8 md:mt-4'>
+              Client Signal
+            </h3>
+            <ChartElement incData={clientSignalHistory} />
+          </div>
         </div>
       </div>
     </Sidebar>

--- a/src/pages/wifisaround.tsx
+++ b/src/pages/wifisaround.tsx
@@ -14,6 +14,7 @@ import {
   IconDefinition,
 } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import clsx from 'clsx';
 import { GetStaticProps } from 'next';
 import { HiWifi } from 'react-icons/hi';
 
@@ -77,6 +78,7 @@ export default function WifisAroundPage(data: SettingsType) {
     ];
     return ddItems;
   };
+
   const wifis = [
     {
       essid: 'Super-Wifi',
@@ -91,6 +93,14 @@ export default function WifisAroundPage(data: SettingsType) {
       pwr: 73,
       enc: 'WPA2',
       ch: 9,
+    },
+  ];
+
+  const clients = [
+    {
+      bssid: '14:fc:1a:bf:42:7b',
+      power: 42,
+      connectedTo: '43:a2:76:fb:ac:1d',
     },
   ];
 
@@ -157,7 +167,19 @@ export default function WifisAroundPage(data: SettingsType) {
                   <tbody className='divide-y divide-neutral-700'>
                     {wifis.map((wifi) => (
                       <tr key={wifi.bssid}>
-                        <td className='whitespace-nowrap px-6 py-4 text-sm font-medium text-neutral-200'>
+                        <td
+                          className={clsx(
+                            clients.filter(
+                              ({ connectedTo }) => connectedTo === wifi.bssid
+                            ).length > 0
+                              ? 'text-primary-300'
+                              : 'text-neutral-200',
+                            'whitespace-nowrap px-6 py-4 text-sm font-medium'
+                          )}
+                        >
+                          {clients.filter(
+                            ({ connectedTo }) => connectedTo === wifi.bssid
+                          ).length > 0 && '* '}
                           {wifi.essid}
                         </td>
                         <td className='whitespace-nowrap px-6 py-4 text-sm text-neutral-200'>

--- a/src/types/settingsType.ts
+++ b/src/types/settingsType.ts
@@ -4,28 +4,28 @@
 // https://opensource.org/licenses/MIT
 
 interface SettingsType {
-  wifiName: string;
-  wifiPwd: string;
-  wifiVisible: boolean;
-  wifiChannel: string;
-  wifiIntIP: string;
-  wifiWPA: string;
-  wifiWPAKeyMgmt: string;
-  wifiWPAPairwise: string;
-  wifiRSNPairwise: string;
-  cardDefault: string;
-  cardDeauth: string;
-  cardMonitor: string;
-  cardHotspot: string;
-  securityBehaviour: string;
-  overrideBehaviour: string;
-  securityInterfaceBehaviour: string;
-  securityTryCount: string;
-  securityPassword: string;
-  deviceLowBattery: string;
-  interfaceAnimatedBG: boolean;
-  interfaceLoginBG: boolean;
-  interfaceZoom: number;
+  wifiName?: string;
+  wifiPwd?: string;
+  wifiVisible?: boolean;
+  wifiChannel?: string;
+  wifiIntIP?: string;
+  wifiWPA?: string;
+  wifiWPAKeyMgmt?: string;
+  wifiWPAPairwise?: string;
+  wifiRSNPairwise?: string;
+  cardDefault?: string;
+  cardDeauth?: string;
+  cardMonitor?: string;
+  cardHotspot?: string;
+  securityBehaviour?: string;
+  overrideBehaviour?: string;
+  securityInterfaceBehaviour?: string;
+  securityTryCount?: string;
+  securityPassword?: string;
+  deviceLowBattery?: string;
+  interfaceAnimatedBG?: boolean;
+  interfaceLoginBG?: boolean;
+  interfaceZoom?: number;
 }
 
 export default SettingsType;

--- a/terminalServer.js
+++ b/terminalServer.js
@@ -16,7 +16,7 @@ const si = require('systeminformation'); // eslint-disable-line
 const app = express();
 const server = http.createServer(app);
 
-app.use(cors());
+app.use(cors({ origin: '*' }));
 
 app.post('/settings', (_, res) => {
   if (fs.existsSync('settings/general.json')) {
@@ -35,7 +35,7 @@ app.post('/setsettings', jsonParse, (req, res) => {
 
 const io = new Server(server, {
   cors: {
-    origin: 'http://localhost:3000',
+    origin: '*',
     methods: ['GET', 'POST'],
   },
 });


### PR DESCRIPTION
# Description & Technical Solution

- Add `victory` dependency for charts.
- Create `ChartElement` for charts.
- Edit "404" page for better visuals.
- Add charts for Wi-Fi signal and client signal sections with maximum values of 12.
- Add **stations with clients** indication to the "Wi-Fi's Around" page.
- Make all of the settings' values optional.
- Accept universal values on `cors` for test purposes. ***Will be changed***

# Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have already run the `npm run prepush` command and there were no issues.
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] Already rebased against main branch.

# Screenshots

None.
