### PR TITLE
feat(frontend, backend): :wrench: Add default settings for handshake page

### DIFF
--- a/settings/general.json
+++ b/settings/general.json
@@ -12,6 +12,8 @@
   "cardDeauth": "Virtual",
   "cardMonitor": "Activate When Needed",
   "cardHotspot": "Virtual",
+  "cardDefaultHandshake": "Aireplay",
+  "cardHandshakeTimeout": "20",
   "securityBehaviour": "Kick Device",
   "overrideBehaviour": "Prevent",
   "securityInterfaceBehaviour": "Kick Device",

--- a/src/pages/handshake.tsx
+++ b/src/pages/handshake.tsx
@@ -27,8 +27,12 @@ export default function GetHandshakePage(data: SettingsType) {
   const [stationList, setStationList] = useState<string[]>([]);
   const [isStart, setIsStart] = useState(false);
   const [currentStatus, setCurrentStatus] = useState('Starting...');
-  const [method, setMethod] = useState('Aireplay');
-  const [tOut, setTOut] = useState('20');
+  const [method, setMethod] = useState(
+    data.cardDefaultHandshake ? data.cardDefaultHandshake : 'Aireplay'
+  );
+  const [tOut, setTOut] = useState(
+    data.cardHandshakeTimeout ? data.cardHandshakeTimeout : '20'
+  );
   return (
     <Sidebar data={data} active='gethandshake'>
       <div className='flex items-center justify-between'>

--- a/src/pages/setup.tsx
+++ b/src/pages/setup.tsx
@@ -69,6 +69,12 @@ export default function SetupPage(data: SettingsType) {
   const [cardDeauth, setCardDeauth] = useState(
     data.cardDeauth ? data.cardDeauth : 'Virtual'
   );
+  const [cardDefaultHandshake, setCardDefaultHandshake] = useState(
+    data.cardDefaultHandshake ? data.cardDefaultHandshake : 'Aireplay'
+  );
+  const [cardHandshakeTimeout, setCardHandshakeTimeout] = useState(
+    data.cardHandshakeTimeout ? data.cardHandshakeTimeout : '20'
+  );
   const [cardMonitor, setCardMonitor] = useState(
     data.cardMonitor ? data.cardMonitor : 'Activate When Needed'
   );
@@ -148,6 +154,8 @@ export default function SetupPage(data: SettingsType) {
           cardDeauth,
           cardMonitor,
           cardHotspot,
+          cardDefaultHandshake,
+          cardHandshakeTimeout,
           securityBehaviour,
           overrideBehaviour,
           securityInterfaceBehaviour,
@@ -207,7 +215,7 @@ export default function SetupPage(data: SettingsType) {
               )}
               onClick={() => setSelTab(1)}
             >
-              Card
+              Card & Monitor
             </button>
             <button
               className={clsx(
@@ -355,6 +363,37 @@ export default function SetupPage(data: SettingsType) {
                       placeholder='Deauth Card'
                       label='Card for Deauth'
                       options={['Virtual', 'wlan1']}
+                    />
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div className='mt-7'>
+              <div className='flex flex-col md:flex-row'>
+                <div className='w-full pr-4 md:w-2/5'>
+                  <h2 className='text-base'>Handshake Values</h2>
+                  <p className='text-sm opacity-80'>
+                    Default values for getting handshake
+                  </p>
+                </div>
+                <div className='mt-3 w-full md:mt-0 md:w-3/5'>
+                  <div className='flex w-full flex-col items-center gap-4 md:flex-row'>
+                    <Select
+                      selected={cardDefaultHandshake}
+                      changeEvt={setCardDefaultHandshake}
+                      placeholder='Default Handshake Method'
+                      label='Handshake Method'
+                      options={[
+                        'Amok MD4',
+                        'Aireplay',
+                        'WIDS / WIPS / WPS Confussion',
+                      ]}
+                    />
+                    <Input
+                      label='Handshake Timeout'
+                      value={cardHandshakeTimeout}
+                      placeholder='20'
+                      changeEvent={setCardHandshakeTimeout}
                     />
                   </div>
                 </div>

--- a/src/types/settingsType.ts
+++ b/src/types/settingsType.ts
@@ -17,6 +17,8 @@ interface SettingsType {
   cardDeauth?: string;
   cardMonitor?: string;
   cardHotspot?: string;
+  cardDefaultHandshake?: string;
+  cardHandshakeTimeout?: string;
   securityBehaviour?: string;
   overrideBehaviour?: string;
   securityInterfaceBehaviour?: string;


### PR DESCRIPTION
# Description & Technical Solution

- Add default handshake method and timeout to settings.
- Link settings with the "Setup" page.
- Link settings with "Get Handshake" page.
- Rename "Card" tab to "Card & Monitor" in "Setup" page.

# Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have already run the `npm run prepush` command and there were no issues.
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] Already rebased against main branch.

# Screenshots

None.
