### PR TITLE
feat(frontend): :wrench: Add search functionality to Wifi's Around page

### DIFF
--- a/src/components/Input.tsx
+++ b/src/components/Input.tsx
@@ -3,20 +3,27 @@
 // This software is released under the MIT License.
 // https://opensource.org/licenses/MIT
 
-import { faEye, faEyeSlash } from '@fortawesome/free-solid-svg-icons';
+import {
+  type IconDefinition,
+  faEye,
+  faEyeSlash,
+} from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import clsx from 'clsx';
 import { ChangeEvent } from 'react';
 import { useState } from 'react';
 
 interface Props {
-  label: string;
+  label?: string;
   value?: string;
   changeEvent: (str: string) => void;
   placeholder?: string;
   start?: string;
   hidable?: boolean;
   autocomplete?: string;
+  fullWidth?: boolean;
+  startIcon?: IconDefinition;
+  className?: string;
 }
 
 export default function Input({
@@ -27,6 +34,9 @@ export default function Input({
   changeEvent,
   hidable = false,
   autocomplete = 'off',
+  fullWidth = true,
+  startIcon,
+  className,
 }: Props) {
   const chgInternal = (e: ChangeEvent<HTMLInputElement>) => {
     changeEvent(e.target.value);
@@ -35,14 +45,26 @@ export default function Input({
   const [isHidden, setIsHidden] = useState(true);
 
   return (
-    <div className='w-full'>
-      <label className='block text-sm font-medium leading-6 text-gray-200'>
-        {label}
-      </label>
+    <div className={clsx(fullWidth && 'w-full')}>
+      {label && (
+        <label className='block text-sm font-medium leading-6 text-gray-200'>
+          {label}
+        </label>
+      )}
       <div className='relative mt-2 rounded-md shadow-sm'>
         {start && (
           <div className='pointer-events-none absolute inset-y-0 left-0 flex items-center pl-3'>
             <span className='text-neutral-500 sm:text-sm'>{start}</span>
+          </div>
+        )}
+        {startIcon && (
+          <div className='pointer-events-none absolute inset-y-0 left-0 flex items-center pl-3'>
+            <FontAwesomeIcon
+              icon={startIcon}
+              className='text-neutral-500'
+              width={13}
+              height={15}
+            />
           </div>
         )}
         <input
@@ -51,7 +73,8 @@ export default function Input({
           value={value}
           autoComplete={autocomplete}
           className={clsx(
-            start ? 'pl-8' : 'pl-3',
+            className && className,
+            start || startIcon ? 'pl-8' : 'pl-3',
             hidable ? 'pr-9' : 'pr-3',
             'focus:ring-primary-300 block w-full rounded-md border-0 bg-neutral-900/40 py-1.5 pr-3 text-neutral-100 ring-1 ring-inset ring-neutral-300 placeholder:text-neutral-500 focus:ring-2 focus:ring-inset sm:text-sm sm:leading-6'
           )}

--- a/src/pages/wifisaround.tsx
+++ b/src/pages/wifisaround.tsx
@@ -11,15 +11,18 @@ import {
   faHouseSignal,
   faLocationCrosshairs,
   faPeopleArrows,
+  faSearch,
   IconDefinition,
 } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import clsx from 'clsx';
 import { GetStaticProps } from 'next';
+import { useEffect, useState } from 'react';
 import { HiWifi } from 'react-icons/hi';
 
 import Button from '@/components/buttons/Button';
 import Dropdown from '@/components/Dropdown';
+import Input from '@/components/Input';
 import Sidebar from '@/components/Sidebar';
 
 import SettingsType from '@/types/settingsType';
@@ -30,7 +33,26 @@ type DropdownLink = {
   clickEvent: () => void;
 };
 
+type ClientType = {
+  bssid: string;
+  power: number;
+  connectedTo: string;
+};
+
+type StationType = {
+  essid: string;
+  bssid: string;
+  pwr: number;
+  enc: string;
+  ch: number;
+};
+
 export default function WifisAroundPage(data: SettingsType) {
+  const [searchClients, setSearchClients] = useState('');
+  const [filteredClients, setFilteredClients] = useState<ClientType[]>([]);
+  const [searchStations, setSearchStations] = useState('');
+  const [filteredStations, setFilteredStations] = useState<StationType[]>([]);
+
   const ddLinkGenerator = (bssid: string) => {
     const ddItems: DropdownLink[] = [
       {
@@ -114,6 +136,33 @@ export default function WifisAroundPage(data: SettingsType) {
     },
   ];
 
+  useEffect(() => {
+    if (searchClients === '') {
+      setFilteredClients(clients);
+    } else {
+      let t = [...clients];
+      t = t.filter((q) =>
+        JSON.stringify(q).toLowerCase().includes(searchClients.toLowerCase())
+      );
+      setFilteredClients(t);
+    }
+  }, [searchClients]); //eslint-disable-line
+
+  useEffect(() => {
+    let t = [...wifis];
+    t = t.sort((a, b) => {
+      return b.pwr - a.pwr;
+    });
+    if (searchStations === '') {
+      setFilteredStations(t);
+    } else {
+      t = t.filter((q) =>
+        JSON.stringify(q).toLowerCase().includes(searchStations.toLowerCase())
+      );
+      setFilteredStations(t);
+    }
+  }, [searchStations]); //eslint-disable-line
+
   return (
     <Sidebar data={data} active='wifis-around'>
       <div className='flex items-center justify-between'>
@@ -125,9 +174,19 @@ export default function WifisAroundPage(data: SettingsType) {
         </Button>
       </div>
       <div className='card custom-bg mt-7 p-5'>
-        <div className='text-primary-300 flex items-center gap-3'>
-          <FontAwesomeIcon icon={faHouseSignal} width={20} />
-          <h3 className='text-xl font-normal md:text-2xl'>Client's List</h3>
+        <div className='flex w-full items-center justify-between'>
+          <div className='text-primary-300 flex items-center gap-3'>
+            <FontAwesomeIcon icon={faHouseSignal} width={20} />
+            <h3 className='text-xl font-normal md:text-2xl'>Client's List</h3>
+          </div>
+          <Input
+            className='w-52'
+            value={searchClients}
+            changeEvent={setSearchClients}
+            startIcon={faSearch}
+            placeholder='Search clients...'
+            fullWidth={false}
+          />
         </div>
         <div className='mt-5 flex flex-col'>
           <div className='-m-1.5'>
@@ -157,7 +216,7 @@ export default function WifisAroundPage(data: SettingsType) {
                     </tr>
                   </thead>
                   <tbody className='divide-y divide-neutral-700'>
-                    {clients.map((client) => (
+                    {filteredClients.map((client) => (
                       <tr key={client.bssid}>
                         <td
                           className={clsx(
@@ -190,9 +249,19 @@ export default function WifisAroundPage(data: SettingsType) {
         </div>
       </div>
       <div className='card custom-bg mt-7 p-5'>
-        <div className='text-primary-300 flex items-center gap-3'>
-          <FontAwesomeIcon icon={faHouseSignal} width={20} />
-          <h3 className='text-xl font-normal md:text-2xl'>Wi-Fi List</h3>
+        <div className='flex items-center justify-between'>
+          <div className='text-primary-300 flex items-center gap-3'>
+            <FontAwesomeIcon icon={faHouseSignal} width={20} />
+            <h3 className='text-xl font-normal md:text-2xl'>Wi-Fi List</h3>
+          </div>
+          <Input
+            className='w-52'
+            value={searchStations}
+            changeEvent={setSearchStations}
+            startIcon={faSearch}
+            placeholder='Search stations...'
+            fullWidth={false}
+          />
         </div>
         <div className='mt-5 flex flex-col'>
           <div className='-m-1.5'>
@@ -240,7 +309,7 @@ export default function WifisAroundPage(data: SettingsType) {
                     </tr>
                   </thead>
                   <tbody className='divide-y divide-neutral-700'>
-                    {wifis.map((wifi) => (
+                    {filteredStations.map((wifi) => (
                       <tr key={wifi.bssid}>
                         <td
                           className={clsx(


### PR DESCRIPTION
# Description & Technical Solution

- Add custom icon input to `Input` component.
- Add option to disable full width attribute on `Input` component.
- Add option for custom class name on `Input` component.
- Add search functionality to clients in "Wi-Fi's Around" page.
- Add search functionality to stations in "Wi-Fi's Around" page.
- Sort Wi-Fi stations according to the power in "Wi-Fi's Around" page.

# Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have already run the `npm run prepush` command and there were no issues.
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] Already rebased against main branch.

# Screenshots

None.
